### PR TITLE
Stringify: Handle null/undefined values

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,5 @@
 export const isPlainObject = (obj) =>
-  typeof obj === "object" && obj.constructor === Object
+  obj !== null && typeof obj === "object" && obj.constructor === Object
 
 export const isArray = (obj) => Array.isArray(obj)
 export const objectHas = (obj, key) => obj.hasOwnProperty(key)

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -6,6 +6,14 @@ const normalizeOptions = (opts) => ({
   encodeKeys: !!opts.encodeKeys,
 })
 
+const formatValue = (value, encoder) => {
+  if (value === null || typeof value === "undefined") {
+    return encoder("")
+  }
+
+  return encoder(value)
+}
+
 const stringify = (key, value, options) => {
   if (isArray(value)) {
     return value
@@ -23,7 +31,7 @@ const stringify = (key, value, options) => {
   }
 
   const keyEncoder = options.encodeKeys ? options.encoder : (str) => str
-  return `${keyEncoder(key)}=${options.encoder(value.toString())}`
+  return `${keyEncoder(key)}=${formatValue(value, options.encoder)}`
 }
 
 export default (obj, opts = {}) => {
@@ -33,5 +41,6 @@ export default (obj, opts = {}) => {
   for (const key in obj) {
     parts.push(stringify(key, obj[key], options))
   }
+
   return parts.join(options.delimiter)
 }

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -31,3 +31,14 @@ test("encodes keys if encodeKeys = true", () => {
     stringify({ "foo/x": { "meow d": "bar" } }, { encodeKeys: true })
   ).toEqual("foo%2Fx%5Bmeow%20d%5D=bar")
 })
+
+test("handles undefined values", () => {
+  expect(stringify({ foo: undefined, bar: "baz" })).toEqual("foo=&bar=baz")
+})
+
+test("handles null values", () => {
+  expect(stringify({ foo: null, bar: "baz" })).toEqual("foo=&bar=baz")
+  expect(stringify({ foo: { a: null, bar: "baz" } })).toEqual(
+    "foo[a]=&foo[bar]=baz"
+  )
+})


### PR DESCRIPTION
For now, this will simply include `key=` in the later-joined values
array. This could potentially accept options to manipulate null and
undefined handling.