### PR TITLE
Stringify: Handle empty arrays

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -42,5 +42,5 @@ export default (obj, opts = {}) => {
     parts.push(stringify(key, obj[key], options))
   }
 
-  return parts.join(options.delimiter)
+  return parts.filter((p) => p.length > 0).join(options.delimiter)
 }

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -42,3 +42,7 @@ test("handles null values", () => {
     "foo[a]=&foo[bar]=baz"
   )
 })
+
+test("handles empty arrays", () => {
+  expect(stringify({ foo: [], bar: "baz" })).toEqual("bar=baz")
+})


### PR DESCRIPTION
For now, when an array is specified and is empty, this should not
include its part in the query string. Open to ideas for options that
make this malleable.