### PR TITLE
parse: Handle leading ? on strings

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -72,7 +72,11 @@ const normalizeParams = (params, key, value, depth) => {
 export default (str, opts = {}) => {
   const params = {}
   const options = normalizeOptions(opts)
-  const qs = str || ""
+  let qs = str || ""
+
+  if (opts["ignoreQueryPrefix"] && qs[0] === "?") {
+    qs = qs.slice(1)
+  }
 
   qs.split(options.delimiter).forEach((part) => {
     const [key, value] = part.split("=").map((p) => options.decoder(p))

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -39,6 +39,14 @@ test("parses array of objects with objects", () => {
   })
 })
 
+test("ignores leading ? on string when configured", () => {
+  expect(parse("?foo=bar", { ignoreQueryPrefix: true })).toEqual({ foo: "bar" })
+})
+
+test("keeps leading ? by default", () => {
+  expect(parse("?foo=bar")).toEqual({ "?foo": "bar" })
+})
+
 test("supports depth option", () => {
   expect(parse("a[][x]=b&a[][y]=c&a[][x]=d&a[][y]=e")).toEqual({
     a: [{ x: "b", y: "c" }, { x: "d", y: "e" }],


### PR DESCRIPTION
[`URL#search`][1] returns a string with a leading `?` character.
If you pass the `search` of a URL directly to rackstring, e.g.
`parse(window.location.search)`, rackstring will currently include that
character as part of the name of the first key parsed out of the query
string. E.g. `?foo=bar` ends up as `{ "?foo": "bar" }`.

Node's built-in `querystring` does the same thing, so if compatibility
with that interface is paramount then this probably shouldn't be
changed. But since I think the most common use cases of `parse` is
probably to parse a `search` string from a `URL` instance or `Location`
instance, this seems like a footgun that might be worth avoiding in this library.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/URL/search