### PR TITLE
Sort object keys when stringifying

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -23,9 +23,9 @@ const stringify = (key, value, options) => {
 
   if (isPlainObject(value)) {
     const parts = []
-    for (const childKey in value) {
+    Object.keys(value).sort().forEach(function(childKey) {
       parts.push(stringify(`${key}[${childKey}]`, value[childKey], options))
-    }
+    })
 
     return parts.join(options.delimiter)
   }

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -14,6 +14,12 @@ test("stringifies objects", () => {
   )
 })
 
+test("sorts keys when stringifying objects", () => {
+  expect(stringify({ foo: { car: "a", baz: "b" } })).toEqual(
+    "foo[baz]=b&foo[car]=a"
+  )
+})
+
 test("stringifies array of objects", () => {
   expect(
     stringify({ foo: [{ bar: "a", baz: "b" }, { bar: "c", baz: "d" }] })


### PR DESCRIPTION
This is what Rails does when generating URLs from params hashes, and I
believe the `stringify` behavior here is intended to imitate Rails
behavior (as opposed to Rack specifically since `Rack::QueryParser`
doesn't do URL generation.

The cases this can matter in are when you have array of objects that
don't all share the exact same set of keys. E.g. `foo: [{a: 1, b: 2}, {a: 2,
c: 3}]`. That *could* be serialized as
`foo[][a]=1&foo[][b]=2&foo[][c]=3&foo[][a]=2`, which will get parsed by
Rails as `foo: [{a: 1, b: 2, c: 3}, {a: 2}]`. Sorting by key, as Rails
does, makes supporting hetergenous keys reliable as long as they share a
key that sorts first.