### PR TITLE
Correctly handle null, undefined, and empty-array values

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -44,7 +44,7 @@ const normalizeParams = (params, key, value, depth) => {
   } else if (after == "[]") {
     params[k] = params[k] || []
     assertArray(k, params[k])
-    params[k].push(value)
+    if (typeof value !== "undefined") params[k].push(value)
   } else {
     const afterMatch =
       after.match(/^\[\]\[([^\[\]]+)\]$/) || after.match(/^\[\](.+)$/)

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -6,18 +6,14 @@ const normalizeOptions = (opts) => ({
   encodeKeys: !!opts.encodeKeys,
 })
 
-const formatValue = (value, encoder) => {
-  if (value === null || typeof value === "undefined") {
-    return encoder("")
-  }
-
-  return encoder(value)
-}
-
 const stringify = (key, value, options) => {
   if (isArray(value)) {
+    const arrKey = `${key}[]`
+
+    if (value.length === 0) return stringify(arrKey, null, options)
+
     return value
-      .map((child) => stringify(`${key}[]`, child, options))
+      .map((child) => stringify(arrKey, child, options))
       .join(options.delimiter)
   }
 
@@ -30,8 +26,12 @@ const stringify = (key, value, options) => {
     return parts.join(options.delimiter)
   }
 
-  const keyEncoder = options.encodeKeys ? options.encoder : (str) => str
-  return `${keyEncoder(key)}=${formatValue(value, options.encoder)}`
+  if ("undefined" === typeof value) return ""
+
+  const parts = [options.encodeKeys ? options.encoder(key) : key]
+  if (value !== null) parts.push(options.encoder(value))
+
+  return parts.join("=")
 }
 
 export default (obj, opts = {}) => {

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -8,6 +8,10 @@ test("parses arrays", () => {
   expect(parse("a[]=b&a[]=c")).toEqual({ a: ["b", "c"] })
 })
 
+test("parses empty arrays", () => {
+  expect(parse("a[]=b&b[]")).toEqual({ a: ["b"], b: [] })
+})
+
 test("parses objects", () => {
   expect(parse("a[b]=c&a[d]=e")).toEqual({
     a: { b: "c", d: "e" },

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -33,16 +33,16 @@ test("encodes keys if encodeKeys = true", () => {
 })
 
 test("handles undefined values", () => {
-  expect(stringify({ foo: undefined, bar: "baz" })).toEqual("foo=&bar=baz")
+  expect(stringify({ foo: undefined, bar: "baz" })).toEqual("bar=baz")
 })
 
 test("handles null values", () => {
-  expect(stringify({ foo: null, bar: "baz" })).toEqual("foo=&bar=baz")
+  expect(stringify({ foo: null, bar: "baz" })).toEqual("foo&bar=baz")
   expect(stringify({ foo: { a: null, bar: "baz" } })).toEqual(
-    "foo[a]=&foo[bar]=baz"
+    "foo[a]&foo[bar]=baz"
   )
 })
 
 test("handles empty arrays", () => {
-  expect(stringify({ foo: [], bar: "baz" })).toEqual("bar=baz")
+  expect(stringify({ foo: [], bar: "baz" })).toEqual("foo[]&bar=baz")
 })


### PR DESCRIPTION
- stringifying: values that were undefined previously generated keys.
now, they do not.
- stringifying: null values included a `=`; now, they do not.
- stringifying: empty arrays would not generate a key; now they do.
- parsing: empty arrays would parse as `[undefined]`. now, they are
parsed as empty arrays.