### PR TITLE
Parser: Consider undefined values `null`

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -26,9 +26,14 @@ const assertPlainObject = (key, obj) => {
 const parseRawValue = (value, options) => {
   if (
     options.parseBooleans &&
+    value !== null &&
     ["true", "false"].includes(value.toString().toLowerCase())
   ) {
     return value.toLowerCase() === "true"
+  }
+
+  if (typeof value === "undefined") {
+    return null
   }
 
   return value

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -56,6 +56,13 @@ test("parses booleans if `parseBooleans` is true", () => {
   })
 })
 
+test("handles null", () => {
+  expect(parse("a=b&b")).toEqual({
+    a: "b",
+    b: null,
+  })
+})
+
 test("throws on type mismatch", () => {
   expect(() => parse("a=b&a[]=c")).toThrow(
     "Expected array (got String) for param a"


### PR DESCRIPTION
This is an important change for round-trip stringification and parsing:
the stringifier will turn a null `b` key to `&b` (no equal), for
example, to `null`, but it is considered undefined when it `&b` is sent
to the parser. We should coerce the value to `null` on parse.